### PR TITLE
Add support for 3D touch

### DIFF
--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -12,11 +12,52 @@
 #import <objc/runtime.h>
 #import "IOKitLib.h"
 
+typedef NS_ENUM(NSInteger, GammaAction) {
+    GammaActionNone,
+    GammaActionEnable,
+    GammaActionDisable
+};
+
 @interface AppDelegate ()
+
+@property (nonatomic, assign) GammaAction action;
 
 @end
 
+static NSString * const ShortcutType = @"ShortcutTypeToggleEnable";
+static NSString * const ShortcutEnable = @"Enable";
+static NSString * const ShortcutDisable = @"Disable";
+
 @implementation AppDelegate
+
+- (void)suspend {
+    UIApplication *app = [UIApplication sharedApplication];
+    [app performSelector:@selector(suspend)];
+}
+
+- (BOOL)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem {
+    if ([shortcutItem.type isEqualToString:ShortcutType]) {
+        if ([GammaController enabled]) {
+            self.action = GammaActionDisable;
+        } else {
+            self.action = GammaActionEnable;
+        }
+        return YES;
+    }
+    return NO;
+}
+
+- (UIApplicationShortcutItem *)shortcutItemForCurrentState {
+    NSString *title = [GammaController enabled] ? ShortcutDisable : ShortcutEnable;
+    UIMutableApplicationShortcutItem *shortcut = [[UIMutableApplicationShortcutItem alloc] initWithType:ShortcutType localizedTitle:title localizedSubtitle:nil icon:nil userInfo:nil];
+    return shortcut;
+}
+
+- (void)updateShortCutItem {
+    UIApplication *application = [UIApplication sharedApplication];
+    UIApplicationShortcutItem *shortcut = [self shortcutItemForCurrentState];
+    application.shortcutItems = @[shortcut];
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
@@ -33,6 +74,10 @@
         @"autoEndMinute": @0,
     }];
     
+    if (!application.shortcutItems.count) {
+        [self updateShortCutItem];
+    }
+    
     return YES;
 }
 
@@ -44,7 +89,7 @@
         completionHandler(UIBackgroundFetchResultNewData);
         return;
     }
-
+    
     NSDateComponents *curTimeComponents = [[NSCalendar currentCalendar] components:NSHourCalendarUnit fromDate:[NSDate date]];
     const NSInteger turnOnHour = [defaults integerForKey:@"autoStartHour"];
     const NSInteger turnOffHour = [defaults integerForKey:@"autoEndHour"];
@@ -78,6 +123,33 @@
     [defaults setObject:[NSDate date] forKey:@"lastAutoChangeDate"];
     
     completionHandler(UIBackgroundFetchResultNewData);
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Calling enableOrangeness/disableOrangeness in -application:performActionForShortcutItem:... causes the app to crash, don't know why..
+    switch (self.action) {
+        case GammaActionEnable:
+            [GammaController enableOrangeness];
+            self.action = GammaActionNone;
+            [self updateShortCutItem];
+            [self suspend];
+            break;
+            
+        case GammaActionDisable:
+            [GammaController disableOrangeness];
+            self.action = GammaActionNone;
+            [self updateShortCutItem];
+            [self suspend];
+            break;
+            
+        default:
+            break;
+    }
+}
+
+- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
+    BOOL handledShortCutItem = [self handleShortcutItem:shortcutItem];
+    completionHandler(handledShortCutItem);
 }
 
 @end

--- a/GammaTest/GammaController.h
+++ b/GammaTest/GammaController.h
@@ -14,5 +14,6 @@
 + (void)setGammaWithOrangeness:(float)percentOrange;
 + (void)enableOrangeness;
 + (void)disableOrangeness;
++ (BOOL)enabled;
 
 @end

--- a/GammaTest/GammaController.m
+++ b/GammaTest/GammaController.m
@@ -168,6 +168,7 @@ extern void SBSUndimScreen();
     [GammaController setGammaWithOrangeness:[defaults floatForKey:@"maxOrange"]];
     [defaults setObject:[NSDate date] forKey:@"lastOnDate"];
     [defaults setBool:YES forKey:@"enabled"];
+    [defaults synchronize];
 }
 
 + (void)disableOrangeness {
@@ -176,6 +177,7 @@ extern void SBSUndimScreen();
     [GammaController setGammaWithOrangeness:0];
     [defaults setObject:[NSDate date] forKey:@"lastOffDate"];
     [defaults setBool:NO forKey:@"enabled"];
+    [defaults synchronize];
 }
 
 + (void)wakeUpScreenIfNeeded {
@@ -186,6 +188,11 @@ extern void SBSUndimScreen();
     NSLog(@"Lock status: %d", isLocked);
     if (isLocked)
         SBSUndimScreen();
+}
+
++ (BOOL)enabled {
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    return [defaults boolForKey:@"enabled"];
 }
 
 @end


### PR DESCRIPTION
This is using dynamic instead of static 3D touch so the shortcut will
reflect the current state of "orangeness".

Additionally, suspend the app when triggered via shortcut.

I noticed after I made this change that someone had [already forked this to add 3D touch](https://github.com/luuuke/GammaThingy/commit/394d2ead362281c1c138f6a90970707dcc2d309a). However, I think this is still worth looking at because unlike the other fork this one uses dynamic 3D touch so the shortcut text will reflect the current state of the gamma setting. Also, I find suspending the app on handling the shortcut to be nice.