### PR TITLE
Add a note to the readme file to disable Reduce White Point 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Besides all that, this is not nearly as complex or well-designed as the actual f
 
 ## Compiling
 This can't be compiled for or run in the simulator so don't try it, it won't work. If you get errors make sure all frameworks are linked correctly, especially IOKit and IOMobileFramebuffer.
+
+## Troubleshooting
+
+If you find the display glitching while GammaThingy is enabled, ensure that you have disabled ```Reduce White Point``` in iOS ```Settings / General / Accessibility / Increase Contracts```


### PR DESCRIPTION
Saw in issue #3 that sometimes there's glitching issues if Reduce White Point is enabled (discovered this while running GammaThingy here).  Threw a note into the README file about this so folks don't have to dig through closed issues to find info on the glitching.