### PR TITLE
Perform gamma change immediately on shortcut

### DIFF
--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -24,8 +24,6 @@ typedef NS_ENUM(NSInteger, GammaAction) {
 
 @interface AppDelegate ()
 
-@property (nonatomic, assign) GammaAction action;
-
 @end
 
 static NSString * const ShortcutType = @"ShortcutTypeToggleEnable";
@@ -37,11 +35,10 @@ static NSString * const ShortcutDisable = @"Disable";
 - (BOOL)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem {
     if ([shortcutItem.type isEqualToString:ShortcutType]) {
         if ([GammaController enabled]) {
-            self.action = GammaActionDisable;
+            [GammaController disableOrangeness];
         } else {
-            self.action = GammaActionEnable;
+            [GammaController enableOrangeness];
         }
-        return YES;
     }
     return NO;
 }
@@ -132,31 +129,10 @@ static NSString * const ShortcutDisable = @"Disable";
     return dict;
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Calling enableOrangeness/disableOrangeness in -application:performActionForShortcutItem:... causes the app to crash, don't know why..
-    switch (self.action) {
-        case GammaActionEnable:
-            [GammaController enableOrangeness];
-            self.action = GammaActionNone;
-            [self updateShortCutItem];
-            [[UIApplication sharedApplication] suspend];
-            break;
-            
-        case GammaActionDisable:
-            [GammaController disableOrangeness];
-            self.action = GammaActionNone;
-            [self updateShortCutItem];
-            [[UIApplication sharedApplication] suspend];
-            break;
-            
-        default:
-            [GammaController autoChangeOrangenessIfNeeded];
-            break;
-    }
-}
-
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
     BOOL handledShortCutItem = [self handleShortcutItem:shortcutItem];
+    [[UIApplication sharedApplication] suspend];
+    [self updateShortCutItem];
     completionHandler(handledShortCutItem);
 }
 

--- a/GammaTest/MainViewController.m
+++ b/GammaTest/MainViewController.m
@@ -10,6 +10,7 @@
 #import "GammaController.h"
 
 @interface MainViewController ()
+
 @property (weak, nonatomic) IBOutlet UISwitch *enabledSwitch;
 @property (weak, nonatomic) IBOutlet UISlider *orangeSlider;
 @property (weak, nonatomic) IBOutlet UISwitch *colorChangingEnabledSwitch;
@@ -32,19 +33,7 @@
     timeFormatter = [[NSDateFormatter alloc] init];
     timeFormatter.timeStyle = NSDateFormatterShortStyle;
     timeFormatter.dateStyle = NSDateFormatterNoStyle;
-    
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-    
-    self.tableView.alwaysBounceVertical = NO;
-    enabledSwitch.on = [defaults boolForKey:@"enabled"];
-    orangeSlider.value = [defaults floatForKey:@"maxOrange"];
-    colorChangingEnabledSwitch.on = [defaults boolForKey:@"colorChangingEnabled"];
-    
-    NSDate *date = [self dateForHour:[defaults integerForKey:@"autoStartHour"] andMinute:[defaults integerForKey:@"autoStartMinute"]];
-    startTimeTextField.text = [timeFormatter stringFromDate:date];
-    date = [self dateForHour:[defaults integerForKey:@"autoEndHour"] andMinute:[defaults integerForKey:@"autoEndMinute"]];
-    endTimeTextField.text = [timeFormatter stringFromDate:date];
-    
+
     timePicker = [[UIDatePicker alloc] init];
     timePicker.datePickerMode = UIDatePickerModeTime;
     [timePicker addTarget:self action:@selector(timePickerValueChanged:) forControlEvents:UIControlEventValueChanged];
@@ -59,6 +48,14 @@
     
     endTimeTextField.delegate = self;
     startTimeTextField.delegate = self;
+
+    [self updateDisplay];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateDisplay) name:@"UIApplicationWillEnterForegroundNotification" object:nil];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (IBAction)enabledSwitchChanged:(UISwitch *)sender {
@@ -136,6 +133,20 @@
     comps.hour = hour;
     comps.minute = minute;
     return [[NSCalendar currentCalendar] dateFromComponents:comps];
+}
+
+- (void)updateDisplay {
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+
+    self.tableView.alwaysBounceVertical = NO;
+    enabledSwitch.on = [defaults boolForKey:@"enabled"];
+    orangeSlider.value = [defaults floatForKey:@"maxOrange"];
+    colorChangingEnabledSwitch.on = [defaults boolForKey:@"colorChangingEnabled"];
+
+    NSDate *date = [self dateForHour:[defaults integerForKey:@"autoStartHour"] andMinute:[defaults integerForKey:@"autoStartMinute"]];
+    startTimeTextField.text = [timeFormatter stringFromDate:date];
+    date = [self dateForHour:[defaults integerForKey:@"autoEndHour"] andMinute:[defaults integerForKey:@"autoEndMinute"]];
+    endTimeTextField.text = [timeFormatter stringFromDate:date];
 }
 
 @end


### PR DESCRIPTION
Previously the shortcut would trigger a state change on the GammaAction
property which would later be used in applicationDidBecomeActive. This
was a workaround for a crash [which is now fixed](https://github.com/thomasfinch/GammaThingy/commit/9535e1d3efd99a7d797958a1ef2f9b65c2997b23).

This patch simplifies the logic and the gamma change happens faster.