### PR TITLE
Background Refresh

### DIFF
--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 				TargetAttributes = {
 					B9E536451B38D90D0097BF90 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 45BADQ7L9R;
+						DevelopmentTeam = WV4RMF773Y;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -155,15 +155,18 @@ static NSString * const ShortcutDisable = @"Disable";
     }
 }
 
-static int counter;
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-//    //Minimun keepAliveTimeout is 600 seconds
-//    [[UIApplication sharedApplication] setKeepAliveTimeout:605 handler:^{
-//        //do your background task
-//        counter ++;
-//        NSLog(@"Counter # %d", counter);
-//    }];
+    NSLog(@"applicationDidEnterBackground");
+    
+    // Timeout is set to 10 minutes this is the minimum
+    [[UIApplication sharedApplication] setKeepAliveTimeout:600 handler:^{
+        NSLog(@"App woke with keep alive timeout");
+        [GammaController autoChangeOrangenessIfNeeded];
+        
+        // TODO Might be possible to implement long transisions with this
+        // Also it could be better to remove fetch requests or deactivate them as long as this works
+    }];
 }
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -155,6 +155,17 @@ static NSString * const ShortcutDisable = @"Disable";
     }
 }
 
+static int counter;
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+//    //Minimun keepAliveTimeout is 600 seconds
+//    [[UIApplication sharedApplication] setKeepAliveTimeout:605 handler:^{
+//        //do your background task
+//        counter ++;
+//        NSLog(@"Counter # %d", counter);
+//    }];
+}
+
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
     BOOL handledShortCutItem = [self handleShortcutItem:shortcutItem];
     completionHandler(handledShortCutItem);

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -59,15 +59,15 @@ static NSString * const ShortcutDisable = @"Disable";
     [application setMinimumBackgroundFetchInterval:900]; //Wake up every 15 minutes at minimum
     
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
-        @"enabled": @NO,
-        @"maxOrange": [NSNumber numberWithFloat:0.7],
-        @"colorChangingEnabled": @YES,
-        @"lastAutoChangeDate": [NSDate distantPast],
-        @"autoStartHour": @19,
-        @"autoStartMinute": @0,
-        @"autoEndHour": @7,
-        @"autoEndMinute": @0,
-    }];
+                                                              @"enabled": @NO,
+                                                              @"maxOrange": [NSNumber numberWithFloat:0.7],
+                                                              @"colorChangingEnabled": @YES,
+                                                              @"lastAutoChangeDate": [NSDate distantPast],
+                                                              @"autoStartHour": @19,
+                                                              @"autoStartMinute": @0,
+                                                              @"autoEndHour": @7,
+                                                              @"autoEndMinute": @0,
+                                                              }];
     
     if ([application respondsToSelector:@selector(shortcutItems)] &&
         !application.shortcutItems.count) {
@@ -130,27 +130,11 @@ static NSString * const ShortcutDisable = @"Disable";
     return dict;
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Calling enableOrangeness/disableOrangeness in -application:performActionForShortcutItem:... causes the app to crash, don't know why..
-    switch (self.action) {
-        case GammaActionEnable:
-            [GammaController enableOrangeness];
-            self.action = GammaActionNone;
-            [self updateShortCutItem];
-            [[UIApplication sharedApplication] suspend];
-            break;
-            
-        case GammaActionDisable:
-            [GammaController disableOrangeness];
-            self.action = GammaActionNone;
-            [self updateShortCutItem];
-            [[UIApplication sharedApplication] suspend];
-            break;
-            
-        default:
-            [GammaController autoChangeOrangenessIfNeeded];
-            break;
-    }
+- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
+    BOOL handledShortCutItem = [self handleShortcutItem:shortcutItem];
+    [[UIApplication sharedApplication] suspend];
+    [self updateShortCutItem];
+    completionHandler(handledShortCutItem);
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
@@ -165,13 +149,6 @@ static NSString * const ShortcutDisable = @"Disable";
         // TODO Might be possible to implement long transisions with this
         // Also it could be better to remove fetch requests or deactivate them as long as this works
     }];
-}
-
-- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
-    BOOL handledShortCutItem = [self handleShortcutItem:shortcutItem];
-    [[UIApplication sharedApplication] suspend];
-    [self updateShortCutItem];
-    completionHandler(handledShortCutItem);
 }
 
 @end

--- a/GammaTest/Info.plist
+++ b/GammaTest/Info.plist
@@ -35,6 +35,7 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>voip</string>
 		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
@@ -46,6 +47,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>CFBundleDisplayName</key>
+	<string>Gamma Thingy</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/GammaTest/MainViewController.m
+++ b/GammaTest/MainViewController.m
@@ -80,6 +80,8 @@
 }
 
 - (IBAction)enabledSwitchChanged:(UISwitch *)sender {
+    NSLog(@"enabled: %lu",(unsigned long)sender.on);
+    
     if (sender.on)
         [GammaController setGammaWithOrangeness:[[NSUserDefaults standardUserDefaults] floatForKey:@"maxOrange"]];
     else
@@ -89,6 +91,7 @@
 }
 
 - (IBAction)maxOrangeSliderChanged:(UISlider *)sender {
+    NSLog(@"maxOrange: %f",sender.value);
     [[NSUserDefaults standardUserDefaults] setFloat:sender.value forKey:@"maxOrange"];
     
     if (enabledSwitch.on)
@@ -96,7 +99,7 @@
 }
 
 - (IBAction)colorChangingEnabledSwitchChanged:(UISwitch *)sender {
-    NSLog(@"color changing switch changed");
+    NSLog(@"colorChangingEnabled: %lu",(unsigned long)sender.on);
     [[NSUserDefaults standardUserDefaults] setBool:sender.on forKey:@"colorChangingEnabled"];
     [[NSUserDefaults standardUserDefaults] setObject:[NSDate distantPast] forKey:@"lastAutoChangeDate"];
     [GammaController autoChangeOrangenessIfNeeded];

--- a/GammaTest/Storyboard.storyboard
+++ b/GammaTest/Storyboard.storyboard
@@ -39,7 +39,7 @@
                                         <rect key="frame" x="0.0" y="99" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Zs9-8L-hUf" id="snd-z7-AzZ">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="NcL-B3-6n9">
@@ -78,7 +78,7 @@
                                         <rect key="frame" x="0.0" y="193" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7VE-VY-qs7" id="8Wt-5u-Fxf">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="5MF-0c-fvX">
@@ -107,7 +107,7 @@
                                         <rect key="frame" x="0.0" y="287" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="99n-2q-Sjq" id="yoE-IK-jwS">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Of2-4s-WYp">


### PR DESCRIPTION
Added preparations for background refresh without depending on the iOS background refreshing using this  [solution](http://stackoverflow.com/questions/12004150/how-to-run-background-process-on-the-ios-using-private-apis-to-sync-email-items#12007135).

This solution could also enable a transition animation equally to f.lux.


Also a small design change:
App is now longer named "GammaTest" on SpringBoard but "Gamma Thingy"