### PR TITLE
add instructions about turning OFF Reduce White Point

### DIFF
--- a/GammaTest/Storyboard.storyboard
+++ b/GammaTest/Storyboard.storyboard
@@ -101,7 +101,7 @@
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Automatic Color Changing" id="ywG-jw-Vjt">
-                                <string key="footerTitle">Automatic color changing uses the background fetch feature to turn on or off orangeness. It doesn't happen immediately when the start or end times are passed, and won't work if background app refresh is disabled or iOS 9 low power mode is on. If your device's screen turns on randomly, that's the app making sure the screen is on before changing the color.</string>
+                                <string key="footerTitle">Automatic color changing uses the background fetch feature to turn on or off orangeness. It doesn't happen immediately when the start or end times are passed, and won't work if background app refresh is disabled or iOS 9 low power mode is on. If your device's screen turns on randomly, that's the app making sure the screen is on before changing the color.  IMPORTANT: If you find the display glitching while GammaThingy is enabled, ensure that you have turned OFF 'Reduce White Point' in: Settings / General / Accessibility / Increase Contrast</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="99n-2q-Sjq">
                                         <rect key="frame" x="0.0" y="287" width="600" height="44"/>


### PR DESCRIPTION
Instructions in README is nice, but it’s better if users see it *while* the glitch is happening.