### PR TITLE
Reboot persistence lock screen wake fix

### DIFF
--- a/GammaTest/GammaController.m
+++ b/GammaTest/GammaController.m
@@ -31,6 +31,13 @@ extern void SBSUndimScreen();
 - (BOOL)isLaterThan:(NSDate*)b;
 @end
 
+// TheClass.h
+@interface TheClass : NSObject
++ (int)count;
+@end
+
+static BOOL firstExecution = YES;
+
 @implementation GammaController
 
 //This function is largely the same as the one in iomfsetgamma.c from Saurik's UIKitTools package. The license is pasted below.
@@ -198,8 +205,11 @@ extern void SBSUndimScreen();
 + (void)autoChangeOrangenessIfNeeded {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
-    if ([defaults boolForKey:@"enabled"]){
+    // Reboot persistence code
+    if ([defaults boolForKey:@"enabled"] && firstExecution){
+        NSLog(@"First execution code was triggered");
         [self enableOrangeness];
+        firstExecution = NO;
     }
     
     if (![defaults boolForKey:@"colorChangingEnabled"]) {

--- a/GammaTest/GammaController.m
+++ b/GammaTest/GammaController.m
@@ -31,11 +31,6 @@ extern void SBSUndimScreen();
 - (BOOL)isLaterThan:(NSDate*)b;
 @end
 
-// TheClass.h
-@interface TheClass : NSObject
-+ (int)count;
-@end
-
 static BOOL firstExecution = YES;
 
 @implementation GammaController


### PR DESCRIPTION
Fixed a bug introduced in my last pull request wich caused the lockscreen to wake every time a fetch request was send