### PR TITLE
Update shortcut item on defaults change

### DIFF
--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -51,6 +51,9 @@ static NSString * const ShortcutDisable = @"Disable";
 
 - (void)updateShortCutItem {
     UIApplication *application = [UIApplication sharedApplication];
+    if (![application respondsToSelector:@selector(shortcutItems)]) {
+        return;
+    }
     UIApplicationShortcutItem *shortcut = [self shortcutItemForCurrentState];
     application.shortcutItems = @[shortcut];
 }
@@ -68,11 +71,13 @@ static NSString * const ShortcutDisable = @"Disable";
                                                               @"autoEndHour": @7,
                                                               @"autoEndMinute": @0,
                                                               }];
-    
-    if ([application respondsToSelector:@selector(shortcutItems)] &&
-        !application.shortcutItems.count) {
-        [self updateShortCutItem];
-    }
+
+    [self updateShortCutItem];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(userDefaultsChanged:)
+                                                 name:NSUserDefaultsDidChangeNotification
+                                               object:nil];
     
     [GammaController autoChangeOrangenessIfNeeded];
     
@@ -141,6 +146,10 @@ static NSString * const ShortcutDisable = @"Disable";
     [[UIApplication sharedApplication] suspend];
     [self updateShortCutItem];
     completionHandler(handledShortCutItem);
+}
+
+- (void)userDefaultsChanged:(NSNotification *)notification {
+    [self updateShortCutItem];
 }
 
 @end


### PR DESCRIPTION
If the state is changed in any way other than via the shortcut
(background app refresh, for example) the shortcut text will be out of
sync with the actual state.

Additional note: this patch also moves the respondsToSelector check into updateShortCutItem so it only has to be done in one place.