### PR TITLE
Today Extension using App Groups

### DIFF
--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -547,7 +547,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				APP_GROUP_IDENTIFIER = group.ahammer.me.GammaTest;
+				APP_GROUP_IDENTIFIER = group.me.ahammer.GammaTest;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -591,7 +591,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				APP_GROUP_IDENTIFIER = group.ahammer.me.GammaTest;
+				APP_GROUP_IDENTIFIER = group.me.ahammer.GammaTest;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0024BBCC1BDF6E85007A5FA1 /* GammaController.m in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7321BCA711300BCC80A /* GammaController.m */; };
 		0024BBCD1BDF6E95007A5FA1 /* solar.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E72A1BCA6D4000BCC80A /* solar.c */; };
 		0024BBCE1BDF6E9A007A5FA1 /* brightness.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7261BCA6A3D00BCC80A /* brightness.c */; };
+		003B304A1BE0CB7000BFF1E6 /* NSUserDefaults+Group.m in Sources */ = {isa = PBXBuildFile; fileRef = 003B30491BE0CB7000BFF1E6 /* NSUserDefaults+Group.m */; };
+		003B304B1BE0CBCA00BFF1E6 /* NSUserDefaults+Group.m in Sources */ = {isa = PBXBuildFile; fileRef = 003B30491BE0CB7000BFF1E6 /* NSUserDefaults+Group.m */; };
 		AFD8E7281BCA6A3D00BCC80A /* brightness.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7261BCA6A3D00BCC80A /* brightness.c */; };
 		AFD8E72C1BCA6D4000BCC80A /* solar.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E72A1BCA6D4000BCC80A /* solar.c */; };
 		AFD8E7331BCA711300BCC80A /* GammaController.m in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7321BCA711300BCC80A /* GammaController.m */; };
@@ -66,6 +68,8 @@
 		0024BBB11BDF6B19007A5FA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		003B30461BE0C96700BFF1E6 /* GammaTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = GammaTest.entitlements; sourceTree = "<group>"; };
 		003B30471BE0C9B700BFF1E6 /* GammaWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = GammaWidget.entitlements; sourceTree = "<group>"; };
+		003B30481BE0CB7000BFF1E6 /* NSUserDefaults+Group.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+Group.h"; path = "extentions/NSUserDefaults+Group.h"; sourceTree = "<group>"; };
+		003B30491BE0CB7000BFF1E6 /* NSUserDefaults+Group.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+Group.m"; path = "extentions/NSUserDefaults+Group.m"; sourceTree = "<group>"; };
 		AFD8E7261BCA6A3D00BCC80A /* brightness.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = brightness.c; path = libs/brightness/brightness.c; sourceTree = "<group>"; };
 		AFD8E7271BCA6A3D00BCC80A /* brightness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = brightness.h; path = libs/brightness/brightness.h; sourceTree = "<group>"; };
 		AFD8E72A1BCA6D4000BCC80A /* solar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = solar.c; path = libs/solar/solar.c; sourceTree = "<group>"; };
@@ -163,12 +167,14 @@
 			path = GammaWidget;
 			sourceTree = "<group>";
 		};
-		AF2C35091BD168C100BBCF8F /* extentions */ = {
+		AF2C35091BD168C100BBCF8F /* extensions */ = {
 			isa = PBXGroup;
 			children = (
 				AFEEB5D11BD1692600F56616 /* NSDate_compare.h */,
+				003B30481BE0CB7000BFF1E6 /* NSUserDefaults+Group.h */,
+				003B30491BE0CB7000BFF1E6 /* NSUserDefaults+Group.m */,
 			);
-			name = extentions;
+			name = extensions;
 			sourceTree = "<group>";
 		};
 		AFD8E7241BCA69CC00BCC80A /* libs */ = {
@@ -242,7 +248,7 @@
 		B9E536481B38D90D0097BF90 /* GammaTest */ = {
 			isa = PBXGroup;
 			children = (
-				AF2C35091BD168C100BBCF8F /* extentions */,
+				AF2C35091BD168C100BBCF8F /* extensions */,
 				AFD8E72D1BCA6E5600BCC80A /* controller */,
 				AFD8E7241BCA69CC00BCC80A /* libs */,
 				B9E5364C1B38D90D0097BF90 /* AppDelegate.h */,
@@ -447,6 +453,7 @@
 				0024BBAD1BDF6B19007A5FA1 /* TodayViewController.m in Sources */,
 				0024BBCE1BDF6E9A007A5FA1 /* brightness.c in Sources */,
 				0024BBCC1BDF6E85007A5FA1 /* GammaController.m in Sources */,
+				003B304B1BE0CBCA00BFF1E6 /* NSUserDefaults+Group.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -460,6 +467,7 @@
 				AFD8E72C1BCA6D4000BCC80A /* solar.c in Sources */,
 				AFD8E7331BCA711300BCC80A /* GammaController.m in Sources */,
 				AFD8E7281BCA6A3D00BCC80A /* brightness.c in Sources */,
+				003B304A1BE0CB7000BFF1E6 /* NSUserDefaults+Group.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		001E848A1BE20544002871BD /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 001E84891BE20544002871BD /* Defaults.plist */; };
+		001E848B1BE20544002871BD /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 001E84891BE20544002871BD /* Defaults.plist */; };
 		0024BBA91BDF6B18007A5FA1 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0024BBA81BDF6B18007A5FA1 /* NotificationCenter.framework */; };
 		0024BBAD1BDF6B19007A5FA1 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */; };
 		0024BBB01BDF6B19007A5FA1 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0024BBAE1BDF6B19007A5FA1 /* MainInterface.storyboard */; };
@@ -60,6 +62,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		001E84891BE20544002871BD /* Defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Defaults.plist; sourceTree = "<group>"; };
 		0024BBA61BDF6B18007A5FA1 /* GammaWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GammaWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0024BBA81BDF6B18007A5FA1 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		0024BBAB1BDF6B19007A5FA1 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
@@ -259,6 +262,7 @@
 				B9B2BD391BA7B86000514B7A /* Storyboard.storyboard */,
 				B9E536551B38D90D0097BF90 /* Assets.xcassets */,
 				B9E5365A1B38D90D0097BF90 /* Info.plist */,
+				001E84891BE20544002871BD /* Defaults.plist */,
 				003B30461BE0C96700BFF1E6 /* GammaTest.entitlements */,
 				B9E536601B38D92C0097BF90 /* IOKit Headers */,
 				B9E536491B38D90D0097BF90 /* Supporting Files */,
@@ -428,6 +432,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				001E848B1BE20544002871BD /* Defaults.plist in Resources */,
 				0024BBB01BDF6B19007A5FA1 /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -436,6 +441,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				001E848A1BE20544002871BD /* Defaults.plist in Resources */,
 				B9E536561B38D90D0097BF90 /* Assets.xcassets in Resources */,
 				B96BB6511B38DAF500F1C3AE /* Launch Screen.xib in Resources */,
 				B9B2BD3A1BA7B86000514B7A /* Storyboard.storyboard in Resources */,

--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -7,20 +7,41 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AFD8E7281BCA6A3D00BCC80A /* brightness.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7261BCA6A3D00BCC80A /* brightness.c */; settings = {ASSET_TAGS = (); }; };
-		AFD8E72C1BCA6D4000BCC80A /* solar.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E72A1BCA6D4000BCC80A /* solar.c */; settings = {ASSET_TAGS = (); }; };
-		AFD8E7331BCA711300BCC80A /* GammaController.m in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7321BCA711300BCC80A /* GammaController.m */; settings = {ASSET_TAGS = (); }; };
+		0024BBA91BDF6B18007A5FA1 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0024BBA81BDF6B18007A5FA1 /* NotificationCenter.framework */; };
+		0024BBAD1BDF6B19007A5FA1 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */; };
+		0024BBB01BDF6B19007A5FA1 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0024BBAE1BDF6B19007A5FA1 /* MainInterface.storyboard */; };
+		0024BBB41BDF6B19007A5FA1 /* GammaWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0024BBA61BDF6B18007A5FA1 /* GammaWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0024BBC81BDF6E2D007A5FA1 /* SpringBoardServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9DCA8871BBDF65900C449B0 /* SpringBoardServices.framework */; };
+		0024BBC91BDF6E7C007A5FA1 /* BackBoardServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B92DD5F81BB33DD700DC6E8F /* BackBoardServices.framework */; };
+		0024BBCA1BDF6E7E007A5FA1 /* IOMobileFramebuffer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B96BB6551B38DDB600F1C3AE /* IOMobileFramebuffer.framework */; };
+		0024BBCB1BDF6E80007A5FA1 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B96BB6531B38DDA500F1C3AE /* IOKit.framework */; };
+		0024BBCC1BDF6E85007A5FA1 /* GammaController.m in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7321BCA711300BCC80A /* GammaController.m */; };
+		0024BBCD1BDF6E95007A5FA1 /* solar.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E72A1BCA6D4000BCC80A /* solar.c */; };
+		0024BBCE1BDF6E9A007A5FA1 /* brightness.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7261BCA6A3D00BCC80A /* brightness.c */; };
+		AFD8E7281BCA6A3D00BCC80A /* brightness.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7261BCA6A3D00BCC80A /* brightness.c */; };
+		AFD8E72C1BCA6D4000BCC80A /* solar.c in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E72A1BCA6D4000BCC80A /* solar.c */; };
+		AFD8E7331BCA711300BCC80A /* GammaController.m in Sources */ = {isa = PBXBuildFile; fileRef = AFD8E7321BCA711300BCC80A /* GammaController.m */; };
 		B92DD5F91BB33DD700DC6E8F /* BackBoardServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B92DD5F81BB33DD700DC6E8F /* BackBoardServices.framework */; };
 		B96BB6511B38DAF500F1C3AE /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B96BB6501B38DAF500F1C3AE /* Launch Screen.xib */; };
 		B96BB6541B38DDA500F1C3AE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B96BB6531B38DDA500F1C3AE /* IOKit.framework */; };
 		B96BB6561B38DDB600F1C3AE /* IOMobileFramebuffer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B96BB6551B38DDB600F1C3AE /* IOMobileFramebuffer.framework */; };
-		B9B2BD3A1BA7B86000514B7A /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B9B2BD391BA7B86000514B7A /* Storyboard.storyboard */; settings = {ASSET_TAGS = (); }; };
+		B9B2BD3A1BA7B86000514B7A /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B9B2BD391BA7B86000514B7A /* Storyboard.storyboard */; };
 		B9DCA8881BBDF65900C449B0 /* SpringBoardServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9DCA8871BBDF65900C449B0 /* SpringBoardServices.framework */; };
 		B9E5364B1B38D90D0097BF90 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B9E5364A1B38D90D0097BF90 /* main.m */; };
 		B9E5364E1B38D90D0097BF90 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B9E5364D1B38D90D0097BF90 /* AppDelegate.m */; };
 		B9E536511B38D90D0097BF90 /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B9E536501B38D90D0097BF90 /* MainViewController.m */; };
 		B9E536561B38D90D0097BF90 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9E536551B38D90D0097BF90 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0024BBB21BDF6B19007A5FA1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9E5363E1B38D90D0097BF90 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0024BBA51BDF6B18007A5FA1;
+			remoteInfo = GammaWidget;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		B9B6D3161BA636DA00A8E999 /* Embed App Extensions */ = {
@@ -29,6 +50,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				0024BBB41BDF6B19007A5FA1 /* GammaWidget.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -36,6 +58,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0024BBA61BDF6B18007A5FA1 /* GammaWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GammaWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0024BBA81BDF6B18007A5FA1 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		0024BBAB1BDF6B19007A5FA1 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		0024BBAF1BDF6B19007A5FA1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		0024BBB11BDF6B19007A5FA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AFD8E7261BCA6A3D00BCC80A /* brightness.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = brightness.c; path = libs/brightness/brightness.c; sourceTree = "<group>"; };
 		AFD8E7271BCA6A3D00BCC80A /* brightness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = brightness.h; path = libs/brightness/brightness.h; sourceTree = "<group>"; };
 		AFD8E72A1BCA6D4000BCC80A /* solar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = solar.c; path = libs/solar/solar.c; sourceTree = "<group>"; };
@@ -87,6 +115,18 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0024BBA31BDF6B18007A5FA1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0024BBC81BDF6E2D007A5FA1 /* SpringBoardServices.framework in Frameworks */,
+				0024BBC91BDF6E7C007A5FA1 /* BackBoardServices.framework in Frameworks */,
+				0024BBCA1BDF6E7E007A5FA1 /* IOMobileFramebuffer.framework in Frameworks */,
+				0024BBCB1BDF6E80007A5FA1 /* IOKit.framework in Frameworks */,
+				0024BBA91BDF6B18007A5FA1 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9E536431B38D90D0097BF90 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -101,6 +141,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0024BBA71BDF6B18007A5FA1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0024BBA81BDF6B18007A5FA1 /* NotificationCenter.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		0024BBAA1BDF6B19007A5FA1 /* GammaWidget */ = {
+			isa = PBXGroup;
+			children = (
+				0024BBAB1BDF6B19007A5FA1 /* TodayViewController.h */,
+				0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */,
+				0024BBAE1BDF6B19007A5FA1 /* MainInterface.storyboard */,
+				0024BBB11BDF6B19007A5FA1 /* Info.plist */,
+			);
+			path = GammaWidget;
+			sourceTree = "<group>";
+		};
 		AF2C35091BD168C100BBCF8F /* extentions */ = {
 			isa = PBXGroup;
 			children = (
@@ -162,6 +221,8 @@
 			isa = PBXGroup;
 			children = (
 				B9E536481B38D90D0097BF90 /* GammaTest */,
+				0024BBAA1BDF6B19007A5FA1 /* GammaWidget */,
+				0024BBA71BDF6B18007A5FA1 /* Frameworks */,
 				B9E536471B38D90D0097BF90 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -170,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				B9E536461B38D90D0097BF90 /* GammaTest.app */,
+				0024BBA61BDF6B18007A5FA1 /* GammaWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -264,6 +326,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0024BBA51BDF6B18007A5FA1 /* GammaWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0024BBB51BDF6B19007A5FA1 /* Build configuration list for PBXNativeTarget "GammaWidget" */;
+			buildPhases = (
+				0024BBA21BDF6B18007A5FA1 /* Sources */,
+				0024BBA31BDF6B18007A5FA1 /* Frameworks */,
+				0024BBA41BDF6B18007A5FA1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GammaWidget;
+			productName = GammaWidget;
+			productReference = 0024BBA61BDF6B18007A5FA1 /* GammaWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		B9E536451B38D90D0097BF90 /* GammaTest */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9E5365D1B38D90D0097BF90 /* Build configuration list for PBXNativeTarget "GammaTest" */;
@@ -276,6 +355,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0024BBB31BDF6B19007A5FA1 /* PBXTargetDependency */,
 			);
 			name = GammaTest;
 			productName = GammaTest;
@@ -288,12 +368,16 @@
 		B9E5363E1B38D90D0097BF90 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Thomas Finch";
 				TargetAttributes = {
+					0024BBA51BDF6B18007A5FA1 = {
+						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = HN76YBFY6K;
+					};
 					B9E536451B38D90D0097BF90 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = WV4RMF773Y;
+						DevelopmentTeam = HN76YBFY6K;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -316,11 +400,20 @@
 			projectRoot = "";
 			targets = (
 				B9E536451B38D90D0097BF90 /* GammaTest */,
+				0024BBA51BDF6B18007A5FA1 /* GammaWidget */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0024BBA41BDF6B18007A5FA1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0024BBB01BDF6B19007A5FA1 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9E536441B38D90D0097BF90 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -334,6 +427,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0024BBA21BDF6B18007A5FA1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0024BBCD1BDF6E95007A5FA1 /* solar.c in Sources */,
+				0024BBAD1BDF6B19007A5FA1 /* TodayViewController.m in Sources */,
+				0024BBCE1BDF6E9A007A5FA1 /* brightness.c in Sources */,
+				0024BBCC1BDF6E85007A5FA1 /* GammaController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9E536421B38D90D0097BF90 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -349,7 +453,66 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		0024BBB31BDF6B19007A5FA1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0024BBA51BDF6B18007A5FA1 /* GammaWidget */;
+			targetProxy = 0024BBB21BDF6B19007A5FA1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		0024BBAE1BDF6B19007A5FA1 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0024BBAF1BDF6B19007A5FA1 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		0024BBB61BDF6B19007A5FA1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/GammaWidget",
+					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks",
+					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/PrivateFrameworks",
+				);
+				INFOPLIST_FILE = GammaWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest.GammaWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		0024BBB71BDF6B19007A5FA1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/GammaWidget",
+					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks",
+					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/PrivateFrameworks",
+				);
+				INFOPLIST_FILE = GammaWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest.GammaWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		B9E5365B1B38D90D0097BF90 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -433,7 +596,6 @@
 		B9E5365E1B38D90D0097BF90 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -445,7 +607,7 @@
 				INFOPLIST_FILE = GammaTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.caspercl.GammaTest;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -455,7 +617,6 @@
 		B9E5365F1B38D90D0097BF90 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -467,7 +628,7 @@
 				INFOPLIST_FILE = GammaTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.caspercl.GammaTest;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -477,6 +638,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0024BBB51BDF6B19007A5FA1 /* Build configuration list for PBXNativeTarget "GammaWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0024BBB61BDF6B19007A5FA1 /* Debug */,
+				0024BBB71BDF6B19007A5FA1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B9E536411B38D90D0097BF90 /* Build configuration list for PBXProject "GammaTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/GammaTest.xcodeproj/project.pbxproj
+++ b/GammaTest.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
 		0024BBAF1BDF6B19007A5FA1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		0024BBB11BDF6B19007A5FA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		003B30461BE0C96700BFF1E6 /* GammaTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = GammaTest.entitlements; sourceTree = "<group>"; };
+		003B30471BE0C9B700BFF1E6 /* GammaWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = GammaWidget.entitlements; sourceTree = "<group>"; };
 		AFD8E7261BCA6A3D00BCC80A /* brightness.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = brightness.c; path = libs/brightness/brightness.c; sourceTree = "<group>"; };
 		AFD8E7271BCA6A3D00BCC80A /* brightness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = brightness.h; path = libs/brightness/brightness.h; sourceTree = "<group>"; };
 		AFD8E72A1BCA6D4000BCC80A /* solar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = solar.c; path = libs/solar/solar.c; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				0024BBAC1BDF6B19007A5FA1 /* TodayViewController.m */,
 				0024BBAE1BDF6B19007A5FA1 /* MainInterface.storyboard */,
 				0024BBB11BDF6B19007A5FA1 /* Info.plist */,
+				003B30471BE0C9B700BFF1E6 /* GammaWidget.entitlements */,
 			);
 			path = GammaWidget;
 			sourceTree = "<group>";
@@ -250,6 +253,7 @@
 				B9B2BD391BA7B86000514B7A /* Storyboard.storyboard */,
 				B9E536551B38D90D0097BF90 /* Assets.xcassets */,
 				B9E5365A1B38D90D0097BF90 /* Info.plist */,
+				003B30461BE0C96700BFF1E6 /* GammaTest.entitlements */,
 				B9E536601B38D92C0097BF90 /* IOKit Headers */,
 				B9E536491B38D90D0097BF90 /* Supporting Files */,
 			);
@@ -374,11 +378,19 @@
 					0024BBA51BDF6B18007A5FA1 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = HN76YBFY6K;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 					B9E536451B38D90D0097BF90 = {
 						CreatedOnToolsVersion = 7.0;
 						DevelopmentTeam = HN76YBFY6K;
 						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
 							com.apple.BackgroundModes = {
 								enabled = 1;
 							};
@@ -476,6 +488,7 @@
 		0024BBB61BDF6B19007A5FA1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = GammaWidget/GammaWidget.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -489,6 +502,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest.GammaWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -496,6 +510,7 @@
 		0024BBB71BDF6B19007A5FA1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = GammaWidget/GammaWidget.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -509,6 +524,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.ahammer.GammaTest.GammaWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -517,6 +533,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_GROUP_IDENTIFIER = group.ahammer.me.GammaTest;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -560,6 +577,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_GROUP_IDENTIFIER = group.ahammer.me.GammaTest;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -597,6 +615,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = GammaTest/GammaTest.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -618,6 +637,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = GammaTest/GammaTest.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -84,6 +84,10 @@ static NSString * const ShortcutDisable = @"Disable";
     return YES;
 }
 
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    [[NSUserDefaults groupDefaults] setBool:YES forKey:@"updateUI"];
+}
+
 - (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler{
     NSLog(@"App woke with fetch request");
 

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -9,7 +9,7 @@
 #import "AppDelegate.h"
 #import "MainViewController.h"
 #import "GammaController.h"
-
+#import "NSUserDefaults+Group.h"
 
 typedef NS_ENUM(NSInteger, GammaAction) {
     GammaActionNone,
@@ -59,7 +59,7 @@ static NSString * const ShortcutDisable = @"Disable";
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [application setMinimumBackgroundFetchInterval:900]; //Wake up every 15 minutes at minimum
     
-    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+    [[NSUserDefaults groupDefaults] registerDefaults:@{
         @"enabled": @NO,
         @"maxOrange": [NSNumber numberWithFloat:0.7],
         @"colorChangingEnabled": @YES,
@@ -108,7 +108,7 @@ static NSString * const ShortcutDisable = @"Disable";
             }
         } else {
             //gammathingy://orangeness/switch
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"enabled"]) {
+            if ([[NSUserDefaults groupDefaults] boolForKey:@"enabled"]) {
                 [GammaController disableOrangeness];
             } else {
                 [GammaController enableOrangeness];

--- a/GammaTest/AppDelegate.m
+++ b/GammaTest/AppDelegate.m
@@ -59,20 +59,9 @@ static NSString * const ShortcutDisable = @"Disable";
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [application setMinimumBackgroundFetchInterval:900]; //Wake up every 15 minutes at minimum
     
-    [[NSUserDefaults groupDefaults] registerDefaults:@{
-        @"enabled": @NO,
-        @"maxOrange": [NSNumber numberWithFloat:0.7],
-        @"colorChangingEnabled": @YES,
-        @"lastAutoChangeDate": [NSDate distantPast],
-        @"autoStartHour": @19,
-        @"autoStartMinute": @0,
-        @"autoEndHour": @7,
-        @"autoEndMinute": @0,
-        @"updateUI":@YES,
-        @"colorChangingLocationLatitude": @0,
-        @"colorChangingLocationLongitude": @0,
-        @"colorChangingLocationEnabled": @NO
-    }];
+    NSString *defaultsPath = [[NSBundle mainBundle] pathForResource:@"Defaults" ofType:@"plist"];
+    NSDictionary *appDefaults = [NSDictionary dictionaryWithContentsOfFile:defaultsPath];
+    [[NSUserDefaults groupDefaults] registerDefaults:appDefaults];
     
     if ([application respondsToSelector:@selector(shortcutItems)] &&
         !application.shortcutItems.count) {

--- a/GammaTest/Defaults.plist
+++ b/GammaTest/Defaults.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>enabled</key>
+	<false/>
+	<key>maxOrange</key>
+	<real>0.7</real>
+	<key>colorChangingEnabled</key>
+	<false/>
+	<key>lastAutoChangeDate</key>
+	<date>1-01-01T00:07:33Z</date>
+	<key>autoStartHour</key>
+	<integer>19</integer>
+	<key>autoStartMinute</key>
+	<integer>0</integer>
+	<key>autoEndHour</key>
+	<integer>7</integer>
+	<key>autoEndMinute</key>
+	<integer>0</integer>
+	<key>updateUI</key>
+	<true/>
+	<key>colorChangingLocationLatitude</key>
+	<integer>0</integer>
+	<key>colorChangingLocationLongitude</key>
+	<integer>0</integer>
+	<key>colorChangingLocationEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/GammaTest/GammaTest.entitlements
+++ b/GammaTest/GammaTest.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.me.ahammer.GammaTest</string>
+	</array>
+</dict>
+</plist>

--- a/GammaTest/Info.plist
+++ b/GammaTest/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>App Group Identifier</key>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/GammaTest/Info.plist
+++ b/GammaTest/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Your location is required once in order to provide location based screen temperature</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Gamma Thingy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -35,6 +35,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Your location is required once in order to provide location based screen temperature</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
@@ -49,8 +51,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>CFBundleDisplayName</key>
-	<string>Gamma Thingy</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/GammaTest/Info.plist
+++ b/GammaTest/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>App Group Identifier</key>
+	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/GammaTest/MainViewController.m
+++ b/GammaTest/MainViewController.m
@@ -100,9 +100,9 @@
     [defaults setBool:NO forKey:@"updateUI"];
     
     if (sender.on) {
-        [GammaController setGammaWithTransitionFrom:0 to:[[NSUserDefaults groupDefaults] floatForKey:@"maxOrange"]];
+        [GammaController enableOrangeness];
     } else {
-        [GammaController setGammaWithTransitionFrom:[[NSUserDefaults groupDefaults] floatForKey:@"maxOrange"] to:0];
+        [GammaController disableOrangeness];
     }
     if ([defaults boolForKey:@"colorChangingLocationEnabled"]) {
         [defaults setBool:NO forKey:@"colorChangingLocationEnabled"];
@@ -111,7 +111,6 @@
         [defaults setBool:NO forKey:@"colorChangingEnabled"];
     }
     
-    [defaults setBool:sender.on forKey:@"enabled"];
     [defaults setBool:YES forKey:@"updateUI"];
     [defaults synchronize];
 }
@@ -149,8 +148,8 @@
     }
     
     [defaults setBool:YES forKey:@"updateUI"];
-    [defaults synchronize];
     [GammaController autoChangeOrangenessIfNeeded];
+    [defaults synchronize];
 }
 
 - (IBAction)colorChangingLocationSwitchValueChanged:(UISwitch *)sender {
@@ -258,8 +257,8 @@
     [defaults setInteger:components.minute forKey:[defaultsKeyPrefix stringByAppendingString:@"Minute"]];
     
     [defaults setObject:[NSDate distantPast] forKey:@"lastAutoChangeDate"];
-    [defaults synchronize];
     [GammaController autoChangeOrangenessIfNeeded];
+    [defaults synchronize];
 }
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {

--- a/GammaTest/MainViewController.m
+++ b/GammaTest/MainViewController.m
@@ -8,6 +8,7 @@
 
 #import "MainViewController.h"
 #import "GammaController.h"
+#import "NSUserDefaults+Group.h"
 
 @interface MainViewController ()
 
@@ -80,7 +81,7 @@
 }
 
 - (void)updateUI {
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults* defaults = [NSUserDefaults groupDefaults];
     
     enabledSwitch.on = [defaults boolForKey:@"enabled"];
     orangeSlider.value = [defaults floatForKey:@"maxOrange"];
@@ -95,28 +96,28 @@
 
 - (IBAction)enabledSwitchChanged:(UISwitch *)sender {
     NSLog(@"enabled: %lu",(unsigned long)sender.on);
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"updateUI"];
+    [[NSUserDefaults groupDefaults] setBool:NO forKey:@"updateUI"];
     
     if (sender.on) {
-        [GammaController setGammaWithTransitionFrom:0 to:[[NSUserDefaults standardUserDefaults] floatForKey:@"maxOrange"]];
+        [GammaController setGammaWithTransitionFrom:0 to:[[NSUserDefaults groupDefaults] floatForKey:@"maxOrange"]];
     } else {
-        [GammaController setGammaWithTransitionFrom:[[NSUserDefaults standardUserDefaults] floatForKey:@"maxOrange"] to:0];
+        [GammaController setGammaWithTransitionFrom:[[NSUserDefaults groupDefaults] floatForKey:@"maxOrange"] to:0];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"colorChangingLocationEnabled"]) {
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
+    if ([[NSUserDefaults groupDefaults] boolForKey:@"colorChangingLocationEnabled"]) {
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"colorChangingLocationEnabled"]) {
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingEnabled"];
+    if ([[NSUserDefaults groupDefaults] boolForKey:@"colorChangingLocationEnabled"]) {
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingEnabled"];
     }
     
     
-    [[NSUserDefaults standardUserDefaults] setBool:sender.on forKey:@"enabled"];
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"updateUI"];
+    [[NSUserDefaults groupDefaults] setBool:sender.on forKey:@"enabled"];
+    [[NSUserDefaults groupDefaults] setBool:YES forKey:@"updateUI"];
 }
 
 - (IBAction)maxOrangeSliderChanged:(UISlider *)sender {
     NSLog(@"maxOrange: %f",sender.value);
-    [[NSUserDefaults standardUserDefaults] setFloat:sender.value forKey:@"maxOrange"];
+    [[NSUserDefaults groupDefaults] setFloat:sender.value forKey:@"maxOrange"];
     
     if (enabledSwitch.on)
         [GammaController setGammaWithOrangeness:sender.value];
@@ -124,9 +125,9 @@
 
 - (IBAction)colorChangingEnabledSwitchChanged:(UISwitch *)sender {
     NSLog(@"colorChangingEnabled: %lu",(unsigned long)sender.on);
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"updateUI"];
-    [[NSUserDefaults standardUserDefaults] setBool:sender.on forKey:@"colorChangingEnabled"];
-    [[NSUserDefaults standardUserDefaults] setObject:[NSDate distantPast] forKey:@"lastAutoChangeDate"];
+    [[NSUserDefaults groupDefaults] setBool:NO forKey:@"updateUI"];
+    [[NSUserDefaults groupDefaults] setBool:sender.on forKey:@"colorChangingEnabled"];
+    [[NSUserDefaults groupDefaults] setObject:[NSDate distantPast] forKey:@"lastAutoChangeDate"];
     NSLog(@"color changing switch changed");
     
     if(sender.on) {
@@ -137,16 +138,16 @@
         // Make the time fields full opacity.
         for(UITableViewCell *cell in timeBasedInputCells)
             [[cell contentView] setAlpha: 1];
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
-        [[NSUserDefaults standardUserDefaults] setBool:sender.on forKey:@"colorChangingEnabled"];
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
+        [[NSUserDefaults groupDefaults] setBool:sender.on forKey:@"colorChangingEnabled"];
     }
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"updateUI"];
+    [[NSUserDefaults groupDefaults] setBool:YES forKey:@"updateUI"];
     [GammaController autoChangeOrangenessIfNeeded];
 }
 
 - (IBAction)colorChangingLocationSwitchValueChanged:(UISwitch *)sender {
     if(sender.on) {
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"updateUI"];
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"updateUI"];
         BOOL requestedLocationAuthorization = NO;
 
         if([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
@@ -167,8 +168,8 @@
             CGFloat latitude = self.locationManager.location.coordinate.latitude;
             CGFloat longitude = self.locationManager.location.coordinate.longitude;
             if (latitude != 0 && longitude != 0) { // make sure the location is available
-                [[NSUserDefaults standardUserDefaults] setFloat:latitude forKey:@"colorChangingLocationLatitude"];
-                [[NSUserDefaults standardUserDefaults] setFloat:longitude forKey:@"colorChangingLocationLongitude"];
+                [[NSUserDefaults groupDefaults] setFloat:latitude forKey:@"colorChangingLocationLatitude"];
+                [[NSUserDefaults groupDefaults] setFloat:longitude forKey:@"colorChangingLocationLongitude"];
             }
             
             [colorChangingEnabledSwitch setOn:NO animated:YES];
@@ -176,8 +177,8 @@
             for(UITableViewCell *cell in timeBasedInputCells) 
                 [[cell contentView] setAlpha: .6];
             
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"colorChangingLocationEnabled"];
-            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingEnabled"];
+            [[NSUserDefaults groupDefaults] setBool:YES forKey:@"colorChangingLocationEnabled"];
+            [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingEnabled"];
             
         } else if(!requestedLocationAuthorization) {
             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"No access to location"
@@ -188,17 +189,17 @@
             [alert show];
             [sender setOn:NO animated:YES];
         }
-        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"updateUI"];
+        [[NSUserDefaults groupDefaults] setBool:YES forKey:@"updateUI"];
         [GammaController autoChangeOrangenessIfNeeded];
     } else {
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
     if (status == kCLAuthorizationStatusDenied) {
         [colorChangingLocationBasedSwitch setOn:NO animated:YES];
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
+        [[NSUserDefaults groupDefaults] setBool:NO forKey:@"colorChangingLocationEnabled"];
     } else if (status == kCLAuthorizationStatusAuthorizedWhenInUse) {
         // revaluate the UISwitch status
         [self colorChangingLocationSwitchValueChanged: colorChangingLocationBasedSwitch];
@@ -238,7 +239,7 @@
     NSDateComponents *components = [[NSCalendar currentCalendar] components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:picker.date];
     currentField.text = [timeFormatter stringFromDate:picker.date];
     
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
     [defaults setInteger:components.hour forKey:[defaultsKeyPrefix stringByAppendingString:@"Hour"]];
     [defaults setInteger:components.minute forKey:[defaultsKeyPrefix stringByAppendingString:@"Minute"]];
     
@@ -247,7 +248,7 @@
 }
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
     NSDate *date = nil;
     if (textField == startTimeTextField) {
         date = [self dateForHour:[defaults integerForKey:@"autoStartHour"] andMinute:[defaults integerForKey:@"autoStartMinute"]];
@@ -267,7 +268,7 @@
 }
 
 - (void)userDefaultsChanged:(NSNotification *)notification {
-    if([[NSUserDefaults standardUserDefaults] boolForKey:@"updateUI"])
+    if([[NSUserDefaults groupDefaults] boolForKey:@"updateUI"])
         [self updateUI];
 }
 

--- a/GammaTest/extentions/NSUserDefaults+Group.h
+++ b/GammaTest/extentions/NSUserDefaults+Group.h
@@ -1,0 +1,19 @@
+//
+//  NSUserDefaults+Group.h
+//  GammaTest
+//
+//  Created by Arthur Hammer on 28.10.15.
+//  Copyright © 2015 Thomas Finch. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSUserDefaults (Group)
+
+// Returns a new NSUserDefaults object for app groups to share defaults in multiple targets.
+// The suit name is the bundles' "App Group Identifier" key.
+//
+// (Note: For now, this returns a new instance on every call.)
++ (NSUserDefaults *)groupDefaults;
+
+@end

--- a/GammaTest/extentions/NSUserDefaults+Group.h
+++ b/GammaTest/extentions/NSUserDefaults+Group.h
@@ -11,7 +11,7 @@
 @interface NSUserDefaults (Group)
 
 // Returns a new NSUserDefaults object for app groups to share defaults in multiple targets.
-// The suit name is the bundles' "App Group Identifier" key.
+// The suit name is the bundles' "AppGroupIdentifier" key.
 //
 // (Note: For now, this returns a new instance on every call.)
 + (NSUserDefaults *)groupDefaults;

--- a/GammaTest/extentions/NSUserDefaults+Group.m
+++ b/GammaTest/extentions/NSUserDefaults+Group.m
@@ -1,0 +1,18 @@
+//
+//  NSUserDefaults+Group.m
+//  GammaTest
+//
+//  Created by Arthur Hammer on 28.10.15.
+//  Copyright © 2015 Thomas Finch. All rights reserved.
+//
+
+#import "NSUserDefaults+Group.h"
+
+@implementation NSUserDefaults (Group)
+
++ (NSUserDefaults *)groupDefaults {
+    NSString *suitName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"App Group Identifier"];
+    return [[NSUserDefaults alloc] initWithSuiteName:suitName];
+}
+
+@end

--- a/GammaTest/extentions/NSUserDefaults+Group.m
+++ b/GammaTest/extentions/NSUserDefaults+Group.m
@@ -11,7 +11,7 @@
 @implementation NSUserDefaults (Group)
 
 + (NSUserDefaults *)groupDefaults {
-    NSString *suitName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"App Group Identifier"];
+    NSString *suitName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroupIdentifier"];
     return [[NSUserDefaults alloc] initWithSuiteName:suitName];
 }
 

--- a/GammaTest/mvc/controller/GammaController.m
+++ b/GammaTest/mvc/controller/GammaController.m
@@ -19,6 +19,7 @@
 #import "solar.h"
 #import "brightness.h"
 #import "NSDate_compare.h"
+#import "NSUserDefaults+Group.h"
 
 typedef void *IOMobileFramebufferRef;
 
@@ -194,7 +195,7 @@ static BOOL firstExecution = YES;
 }
 
 + (void)enableOrangeness {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
     
     // Making sure orangeness is not enabled
     if(![defaults boolForKey:@"enabled"]){
@@ -208,7 +209,7 @@ static BOOL firstExecution = YES;
 }
 
 + (void)disableOrangeness {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
     
     // Making sure orangeness is not disabled
     if([defaults boolForKey:@"enabled"]){
@@ -233,7 +234,7 @@ static BOOL firstExecution = YES;
 }
 
 + (void) autoChangeOrangenessIfNeeded {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
 
     // Reboot persistence check
     if (firstExecution) {
@@ -338,7 +339,7 @@ static BOOL firstExecution = YES;
 }
 	
 + (BOOL)enabled {
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults* defaults = [NSUserDefaults groupDefaults];
     return [defaults boolForKey:@"enabled"];
 }
 

--- a/GammaTest/mvc/controller/GammaController.m
+++ b/GammaTest/mvc/controller/GammaController.m
@@ -109,10 +109,23 @@ static BOOL firstExecution = YES;
     uint32_t data[0xc0c / sizeof(uint32_t)];
     memset(data, 0, sizeof(data));
     
+    // Hack to share a single gammatable.dat file between host app and Today widget.
+    // Otherwise, it can happen that the widget initializes its gammatable.dat with the existing gamma
+    // from the host app instead of the default screen values (or vice versa). In that case, the widget
+    // won't be able to fully turn off gamma.
+    //
+    // Issues:
+    //   - Not thread-safe. The file is written only once, but still.
+    //   - Tying the GammaController to app group logic makes it less general.
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    NSString *suitName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroupIdentifier"];
+    NSURL* containerURL = [fileManager containerURLForSecurityApplicationGroupIdentifier:suitName];
+    NSString* filePath = [[containerURL path] stringByAppendingString:@"/gammatable.dat"];
+
     //Create the path string pointing to the temporary gamma table file
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *documentsDirectory = [paths objectAtIndex:0];
-    NSString *filePath = [documentsDirectory stringByAppendingString:@"/gammatable.dat"];
+    //NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    //NSString *documentsDirectory = [paths objectAtIndex:0];
+    //NSString *filePath = [documentsDirectory stringByAppendingString:@"/gammatable.dat"];
     FILE *file = fopen([filePath UTF8String], "rb");
     
     if (file == NULL) {

--- a/GammaTest/mvc/controller/GammaController.m
+++ b/GammaTest/mvc/controller/GammaController.m
@@ -336,6 +336,7 @@ static BOOL firstExecution = YES;
     }
     
     [defaults setObject:[NSDate date] forKey:@"lastAutoChangeDate"];
+    [defaults synchronize];
 }
 	
 + (BOOL)enabled {

--- a/GammaWidget/Base.lproj/MainInterface.storyboard
+++ b/GammaWidget/Base.lproj/MainInterface.storyboard
@@ -1,33 +1,137 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M4Y-Lb-cyx">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--Today View Controller-->
         <scene sceneID="cwh-vc-ff4">
             <objects>
-                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
                         <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="33"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
-                                <rect key="frame" x="20" y="8" width="280" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q7A-B4-r2n">
+                                <rect key="frame" x="0.0" y="0.0" width="75" height="33"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="li5-16-9nm">
+                                    <rect key="frame" x="0.0" y="0.0" width="75" height="33"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pAf-D8-wNw">
+                                            <rect key="frame" x="0.0" y="0.0" width="75" height="33"/>
+                                            <animations/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            <state key="normal" title="Enable">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <state key="selected" title="Disable"/>
+                                            <connections>
+                                                <action selector="toggle:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="KMH-6j-piA"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <animations/>
+                                </view>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="75" id="Mq5-A2-UA5"/>
+                                    <constraint firstAttribute="height" constant="33" id="PUS-GL-lpK"/>
+                                </constraints>
+                                <blurEffect style="light"/>
+                            </visualEffectView>
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aYe-bf-vgU">
+                                <rect key="frame" x="83" y="0.0" width="80" height="33"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="vb1-GN-3hE">
+                                    <rect key="frame" x="0.0" y="0.0" width="80" height="33"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCP-KX-ahw">
+                                            <rect key="frame" x="0.0" y="0.0" width="80" height="33"/>
+                                            <animations/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <state key="normal" title="Increase">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <state key="disabled">
+                                                <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="increase:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="Yv5-cg-EzA"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <animations/>
+                                </view>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="4KA-B3-Bv9"/>
+                                    <constraint firstAttribute="height" constant="33" id="MnH-rf-abr"/>
+                                </constraints>
+                                <blurEffect style="light"/>
+                            </visualEffectView>
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uv8-3M-ZUU">
+                                <rect key="frame" x="171" y="0.0" width="80" height="33"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="yEs-OP-T42">
+                                    <rect key="frame" x="0.0" y="0.0" width="80" height="33"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7FR-va-tED">
+                                            <rect key="frame" x="0.0" y="0.0" width="80" height="33"/>
+                                            <animations/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <state key="normal" title="Decrease">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <state key="disabled">
+                                                <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="decrease:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="8LL-UC-eVc"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <animations/>
+                                </view>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="Cn1-gu-j4b"/>
+                                    <constraint firstAttribute="height" constant="33" id="P8b-Sz-4F3"/>
+                                </constraints>
+                                <blurEffect style="light"/>
+                            </visualEffectView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S3b-od-4gF">
+                                <rect key="frame" x="270" y="0.0" width="30" height="33"/>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="33" id="Df3-pX-T51"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <state key="normal" title="→">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="openApp:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="UG8-Rv-M3N"/>
+                                </connections>
+                            </button>
                         </subviews>
+                        <animations/>
                         <constraints>
-                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
-                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                            <constraint firstItem="S3b-od-4gF" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uv8-3M-ZUU" secondAttribute="trailing" id="D7Z-fX-Qol"/>
+                            <constraint firstAttribute="trailing" secondItem="S3b-od-4gF" secondAttribute="trailing" priority="750" constant="20" symbolic="YES" id="Uax-gt-b4v"/>
+                            <constraint firstItem="S3b-od-4gF" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" id="XLd-x4-m9T"/>
+                            <constraint firstItem="Q7A-B4-r2n" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" id="edb-cH-0pq"/>
+                            <constraint firstItem="aYe-bf-vgU" firstAttribute="leading" secondItem="Q7A-B4-r2n" secondAttribute="trailing" constant="8" id="gDA-e7-4Cd"/>
+                            <constraint firstItem="uv8-3M-ZUU" firstAttribute="leading" secondItem="aYe-bf-vgU" secondAttribute="trailing" constant="8" id="gV3-yA-ymg"/>
+                            <constraint firstItem="uv8-3M-ZUU" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" id="ggv-Fm-BvA"/>
+                            <constraint firstItem="aYe-bf-vgU" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" id="htC-oW-TbL"/>
+                            <constraint firstItem="Q7A-B4-r2n" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" id="ngw-hF-vlk"/>
                         </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
@@ -35,16 +139,19 @@
                     <nil key="simulatedTopBarMetrics"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="320" height="37"/>
+                    <size key="freeformSize" width="320" height="33"/>
+                    <connections>
+                        <outlet property="decreaseButton" destination="7FR-va-tED" id="7Zg-xC-wqj"/>
+                        <outlet property="decreaseView" destination="uv8-3M-ZUU" id="yPW-r5-xeC"/>
+                        <outlet property="increaseButton" destination="HCP-KX-ahw" id="ywc-dv-sKf"/>
+                        <outlet property="increaseView" destination="aYe-bf-vgU" id="j6y-07-lLE"/>
+                        <outlet property="toggleButton" destination="pAf-D8-wNw" id="MLe-pi-uoX"/>
+                        <outlet property="toggleView" destination="Q7A-B4-r2n" id="gt7-cJ-qsy"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="516" y="285"/>
+            <point key="canvasLocation" x="-282" y="-200.5"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/GammaWidget/Base.lproj/MainInterface.storyboard
+++ b/GammaWidget/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
+                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <rect key="frame" x="20" y="8" width="280" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="37"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="516" y="285"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/GammaWidget/GammaWidget.entitlements
+++ b/GammaWidget/GammaWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.me.ahammer.GammaTest</string>
+	</array>
+</dict>
+</plist>

--- a/GammaWidget/Info.plist
+++ b/GammaWidget/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>App Group Identifier</key>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/GammaWidget/Info.plist
+++ b/GammaWidget/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Gamma Thingy</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/GammaWidget/Info.plist
+++ b/GammaWidget/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>App Group Identifier</key>
+	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/GammaWidget/TodayViewController.h
+++ b/GammaWidget/TodayViewController.h
@@ -1,0 +1,13 @@
+//
+//  TodayViewController.h
+//  GammaWidget
+//
+//  Created by Arthur Hammer on 27.10.15.
+//  Copyright © 2015 Thomas Finch. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface TodayViewController : UIViewController
+
+@end

--- a/GammaWidget/TodayViewController.m
+++ b/GammaWidget/TodayViewController.m
@@ -15,6 +15,10 @@
 @property IBOutlet UIButton *toggleButton;
 @property IBOutlet UIButton *increaseButton;
 @property IBOutlet UIButton *decreaseButton;
+
+@property IBOutlet UIVisualEffectView *toggleView;
+@property IBOutlet UIVisualEffectView *increaseView;
+@property IBOutlet UIVisualEffectView *decreaseView;
 @end
 
 @implementation TodayViewController
@@ -23,6 +27,15 @@ float increaseOrangenessBy = 0.1f;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.preferredContentSize = CGSizeMake(0, 33);
+    
+    self.toggleView.layer.cornerRadius = 5;
+    self.increaseView.layer.cornerRadius = 5;
+    self.decreaseView.layer.cornerRadius = 5;
+    
+    self.toggleView.clipsToBounds = YES;
+    self.increaseView.clipsToBounds = YES;
+    self.decreaseView.clipsToBounds = YES;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -35,6 +48,10 @@ float increaseOrangenessBy = 0.1f;
     self.toggleButton.selected = enabled;
     self.increaseButton.enabled = enabled;
     self.decreaseButton.enabled = enabled;
+}
+
+- (UIEdgeInsets)widgetMarginInsetsForProposedMarginInsets:(UIEdgeInsets)defaultMarginInsets {
+    return UIEdgeInsetsMake(10, defaultMarginInsets.left, 10, defaultMarginInsets.right);
 }
 
 - (IBAction)toggle:(id)sender {

--- a/GammaWidget/TodayViewController.m
+++ b/GammaWidget/TodayViewController.m
@@ -36,6 +36,9 @@ float increaseOrangenessBy = 0.1f;
     self.toggleView.clipsToBounds = YES;
     self.increaseView.clipsToBounds = YES;
     self.decreaseView.clipsToBounds = YES;
+    NSString *defaultsPath = [[NSBundle mainBundle] pathForResource:@"Defaults" ofType:@"plist"];
+    NSDictionary *appDefaults = [NSDictionary dictionaryWithContentsOfFile:defaultsPath];
+    [[NSUserDefaults groupDefaults] registerDefaults:appDefaults];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/GammaWidget/TodayViewController.m
+++ b/GammaWidget/TodayViewController.m
@@ -1,0 +1,38 @@
+//
+//  TodayViewController.m
+//  GammaWidget
+//
+//  Created by Arthur Hammer on 27.10.15.
+//  Copyright © 2015 Thomas Finch. All rights reserved.
+//
+
+#import "TodayViewController.h"
+#import <NotificationCenter/NotificationCenter.h>
+
+@interface TodayViewController () <NCWidgetProviding>
+
+@end
+
+@implementation TodayViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view from its nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
+    // Perform any setup necessary in order to update the view.
+    
+    // If an error is encountered, use NCUpdateResultFailed
+    // If there's no update required, use NCUpdateResultNoData
+    // If there's an update, use NCUpdateResultNewData
+
+    completionHandler(NCUpdateResultNewData);
+}
+
+@end

--- a/GammaWidget/TodayViewController.m
+++ b/GammaWidget/TodayViewController.m
@@ -8,31 +8,90 @@
 
 #import "TodayViewController.h"
 #import <NotificationCenter/NotificationCenter.h>
+#import "GammaController.h"
+#import "NSUserDefaults+Group.h"
 
 @interface TodayViewController () <NCWidgetProviding>
-
+@property IBOutlet UIButton *toggleButton;
+@property IBOutlet UIButton *increaseButton;
+@property IBOutlet UIButton *decreaseButton;
 @end
 
 @implementation TodayViewController
 
+float increaseOrangenessBy = 0.1f;
+
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view from its nib.
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [GammaController autoChangeOrangenessIfNeeded];
+    [self updateUI];
+}
+
+- (void)updateUI {
+    BOOL enabled = [[NSUserDefaults groupDefaults] boolForKey:@"enabled"];
+    self.toggleButton.selected = enabled;
+    self.increaseButton.enabled = enabled;
+    self.decreaseButton.enabled = enabled;
+}
+
+- (IBAction)toggle:(id)sender {
+    if ([[NSUserDefaults groupDefaults] boolForKey:@"enabled"]) {
+        [GammaController disableOrangeness];
+    } else {
+        [GammaController enableOrangeness];
+    }
+    [self updateUI];
+}
+
+- (IBAction)increase:(id)sender {
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
+    
+    if ([defaults boolForKey:@"enabled"]) {
+        float intensity = [defaults floatForKey:@"maxOrange"];
+        float newIntensity = intensity + increaseOrangenessBy;
+        newIntensity = newIntensity >= 1 ? 1 : newIntensity;
+        [GammaController setGammaWithTransitionFrom:intensity to:newIntensity];
+        // This should be somewhere else, no?
+        [defaults setFloat:newIntensity forKey:@"maxOrange"];
+        [defaults synchronize];
+        [self updateUI];
+    }
+}
+
+- (IBAction)decrease:(id)sender {
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
+    
+    if ([defaults boolForKey:@"enabled"]) {
+        float intensity = [defaults floatForKey:@"maxOrange"];
+        float newIntensity = intensity - increaseOrangenessBy;
+        newIntensity = newIntensity <= 0 ? 0 : newIntensity;
+        [GammaController setGammaWithTransitionFrom:intensity to:newIntensity];
+        // This should be somewhere else, no?
+        [defaults setFloat:newIntensity forKey:@"maxOrange"];
+        [defaults synchronize];
+        [self updateUI];
+    }
+}
+
+- (IBAction)openApp:(id)sender {
+    [[self extensionContext] openURL:[NSURL URLWithString:@"gammathingy://"] completionHandler:nil];
 }
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
-    // Perform any setup necessary in order to update the view.
+    NSUserDefaults *defaults = [NSUserDefaults groupDefaults];
+    BOOL enabledOnLastCheck = [defaults boolForKey:@"widgetLastCheckEnabled"];
+    BOOL enabled = [defaults boolForKey:@"enabled"];
+    [defaults setBool:enabled forKey:@"widgetLastCheckEnabled"];
+    [defaults synchronize];
     
-    // If an error is encountered, use NCUpdateResultFailed
-    // If there's no update required, use NCUpdateResultNoData
-    // If there's an update, use NCUpdateResultNewData
-
-    completionHandler(NCUpdateResultNewData);
+    completionHandler(enabledOnLastCheck != enabled ? NCUpdateResultNewData : NCUpdateResultNoData);
 }
 
 @end


### PR DESCRIPTION
#33 introduced a basic widget. I've been looking into a full widget. Since this required quite a bit of more work, I made this a new PR.

<img src="https://cloud.githubusercontent.com/assets/4521216/10815766/6f029fba-7e2e-11e5-9281-4186fc4e66bb.jpg" alt="alt text" width="300" height="">

UI and functions are simple but it's a good base to work from. I've been running this for a few days and it's quite stable.

#### Main Changes

##### App Groups

Extension and host app live in separate processes. They can only talk by using  [App Groups](http://www.atomicbird.com/blog/sharing-with-app-extensions). Changing to app groups requires a bit of work:

- Enabling App Group Capability for both host and extension.
- Adding a group identifier, usually `group.<main bundle ID>`.

Problem: As with the main bundle ID, it seems we can’t share a group ID. Everyone has their own. The best I came up with:

- Adding a project setting `APP_GROUP_IDENTIFIER` for everybody to set their group ID. 
- In code, getting the identifier from the Info.plist. 

##### NSUserDefaults

- To share defaults, now use `[[NSUserDefaults alloc] initWithSuiteName:<group ID>]` instead of `standardUserDefaults`. I added a category so we can just call `[NSUserDefaults groupDefaults]`.
- Call `[defaults synchronize]` when making changes.
- It seems `NSUserDefaultsDidChangeNotification` [won't get delivered between widget and app](http://stackoverflow.com/questions/28284989/nsuserdefaultsdidchangenotification-and-today-extensions). 

##### GammaController

App and widget have their own `GammaController` class which write to their own `gammatable.dat` file. This leads to the problem where the widget initializes its file with already modified gamma data instead of the default screen values (or vice versa). It will then use this wrong data as the base level for adjustments.

I changed it to write the `gammatable.dat` into the shared app group space. Works for now but is not protected against concurrent writes. Although it's unlikely widget and app will write at the same time, this should be resolved. Maybe there is a better solution altogether that does not clutter GammaController with app group related stuff.

##### Problem

The group ID stuff increases the barrier to entry for users who just want to install the thing. You now have to: (see linked screenshots)

- [Add custom bundle ID to the main app (as before)](https://cloud.githubusercontent.com/assets/4521216/10819152/d94683ce-7e46-11e5-9472-17a2ac69dc0a.png)
- [Add custom bundle ID to the extension](https://cloud.githubusercontent.com/assets/4521216/10819167/e688ef40-7e46-11e5-896f-7147794e5680.png)
- Create a group ID, add it to both [main app](https://cloud.githubusercontent.com/assets/4521216/10819192/ff74ff76-7e46-11e5-8ee6-a5bb1f6d39b1.png) and [extension](https://cloud.githubusercontent.com/assets/4521216/10819204/0b2be370-7e47-11e5-8093-2947e89d6bce.png) 
- [Insert the group ID into the project setting](https://cloud.githubusercontent.com/assets/4521216/10819210/1cf99e76-7e47-11e5-87ca-9647843ee745.png)

I'm open for contributions and happy to change stuff as needed. 

See also #14, #33.